### PR TITLE
Adds ability for /induct to remove an applicant role, and adds relevant applicant property, error, and startup warning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Users of the bot may encounter error codes when attempting to execute slash-comm
 * `E1022` - The CSS Discord server does not contain a role with the name "Guest" (required for the `/induct`, `/makemember`, `/stats` & `/archive` commands and the `kick_no_introduction_members` & `introduction_reminder` tasks)
 * `E1023` - The CSS Discord server does not contain a role with the name "Member" (required for the `/makemember` command)
 * `E1024` - The CSS Discord server does not contain a role with the name "Archivist" (required for the `/archive` command)
+* `E1025` - The CSS Discord server does not contain a role with the name "Applicant" (required for the `/induct` command)
 * `E1031` - The CSS Discord server does not contain a text channel with the name "#roles" (required for the `/writeroles` command)
 * `E1032` - The CSS Discord server does not contain a text channel with the name "#general" (required for the `/induct` command)
 * `E1041` - The guild member IDs could not be retrieved from the MEMBERS_PAGE_URL

--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -22,7 +22,7 @@ import utils
 from cogs.utils import TeXBotAutocompleteContext, TeXBotCog
 from config import settings
 from db.core.models import DiscordReminder, LeftMember, UoBMadeMember
-from exceptions import ArchivistRoleDoesNotExist, CommitteeRoleDoesNotExist, GeneralChannelDoesNotExist, GuestRoleDoesNotExist, GuildDoesNotExist, MemberRoleDoesNotExist, RolesChannelDoesNotExist
+from exceptions import ApplicantRoleDoesNotExist, ArchivistRoleDoesNotExist, CommitteeRoleDoesNotExist, GeneralChannelDoesNotExist, GuestRoleDoesNotExist, GuildDoesNotExist, MemberRoleDoesNotExist, RolesChannelDoesNotExist
 from utils import TeXBot
 
 
@@ -113,6 +113,16 @@ class ApplicationCommandsCog(TeXBotCog):
                 logging_message=str(CommitteeRoleDoesNotExist())
             )
             return
+        
+        applicant_role: discord.Role | None = self.bot.applicant_role
+        if not applicant_role:
+            await self.send_error(
+                ctx,
+                error_code="E1025",
+                command_name="induct",
+                logging_message=str(ApplicantRoleDoesNotExist())
+            )
+            return
 
         interaction_member: discord.Member | None = guild.get_member(ctx.user.id)
         if not interaction_member:
@@ -170,6 +180,11 @@ class ApplicationCommandsCog(TeXBotCog):
             await general_channel.send(
                 f"""{random.choice(settings["WELCOME_MESSAGES"]).replace("<User>", induction_member.mention).strip()} :tada:\nRemember to grab your roles in {roles_channel_mention} and say hello to everyone here! :wave:"""
             )
+
+        await induction_member.remove_roles(
+            applicant_role,  # type: ignore
+            reason=f"{ctx.user} used TeX Bot slash-command: \"/induct\""
+        )
 
         await induction_member.add_roles(
             guest_role,  # type: ignore

--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -115,14 +115,6 @@ class ApplicationCommandsCog(TeXBotCog):
             return
         
         applicant_role: discord.Role | None = self.bot.applicant_role
-        if not applicant_role:
-            await self.send_error(
-                ctx,
-                error_code="E1025",
-                command_name="induct",
-                logging_message=str(ApplicantRoleDoesNotExist())
-            )
-            return
 
         interaction_member: discord.Member | None = guild.get_member(ctx.user.id)
         if not interaction_member:
@@ -181,10 +173,11 @@ class ApplicationCommandsCog(TeXBotCog):
                 f"""{random.choice(settings["WELCOME_MESSAGES"]).replace("<User>", induction_member.mention).strip()} :tada:\nRemember to grab your roles in {roles_channel_mention} and say hello to everyone here! :wave:"""
             )
 
-        await induction_member.remove_roles(
-            applicant_role,  # type: ignore
-            reason=f"{ctx.user} used TeX Bot slash-command: \"/induct\""
-        )
+        if applicant_role:
+            await induction_member.remove_roles(
+                applicant_role,  # type: ignore
+                reason=f"{ctx.user} used TeX Bot slash-command: \"/induct\""
+            )
 
         await induction_member.add_roles(
             guest_role,  # type: ignore

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -9,7 +9,7 @@ from discord_logging.handler import DiscordHandler
 
 from cogs.utils import TeXBotCog
 from db.core.models import IntroductionReminderOptOutMember, LeftMember
-from exceptions import ArchivistRoleDoesNotExist, CommitteeRoleDoesNotExist, GeneralChannelDoesNotExist, GuestRoleDoesNotExist, GuildDoesNotExist, MemberRoleDoesNotExist, RolesChannelDoesNotExist
+from exceptions import ApplicantRoleDoesNotExist, ArchivistRoleDoesNotExist, CommitteeRoleDoesNotExist, GeneralChannelDoesNotExist, GuestRoleDoesNotExist, GuildDoesNotExist, MemberRoleDoesNotExist, RolesChannelDoesNotExist
 from config import settings
 from utils import TeXBot
 from .tasks import TasksCog
@@ -62,6 +62,9 @@ class Events_Cog(TeXBotCog):
 
         if not discord.utils.get(guild.roles, name="Archivist"):
             logging.warning(ArchivistRoleDoesNotExist())
+
+        if not discord.utils.get(guild.roles, name="Applicant"):
+            logging.warning(ApplicantRoleDoesNotExist())
 
         if not discord.utils.get(guild.text_channels, name="roles"):
             logging.warning(RolesChannelDoesNotExist())

--- a/exceptions.py
+++ b/exceptions.py
@@ -266,6 +266,17 @@ class ArchivistRoleDoesNotExist(RoleDoesNotExist):
         super().__init__(message, role_name="Archivist", dependant_commands={"archive"})
 
 
+class ApplicantRoleDoesNotExist(RoleDoesNotExist):
+    """
+        Exception class to raise when the required Discord role with the name
+        "Member" does not exist.
+    """
+
+    def __init__(self, message: str | None = None) -> None:
+        # noinspection SpellCheckingInspection
+        super().__init__(message, role_name="Applicant", dependant_commands={"induct"})
+
+
 class ChannelDoesNotExist(BaseDoesNotExistError):
     """
         Exception class to raise when a required Discord channel with the given

--- a/utils.py
+++ b/utils.py
@@ -201,6 +201,7 @@ class TeXBot(discord.Bot):
         self._guest_role: discord.Role | None = None
         self._member_role: discord.Role | None = None
         self._archivist_role: discord.Role | None = None
+        self._applicant_role: discord.Role | None = None
         self._roles_channel: discord.TextChannel | None = None
         self._general_channel: discord.TextChannel | None = None
         self._welcome_channel: discord.TextChannel | None = None
@@ -241,6 +242,13 @@ class TeXBot(discord.Bot):
             self._archivist_role = discord.utils.get(self.css_guild.roles, name="Archivist")
 
         return self._archivist_role
+    
+    @property
+    def applicant_role(self) -> discord.Role | None:
+        if not self._applicant_role or not discord.utils.get(self.css_guild.roles, id=self._applicant_role.id):
+            self._applicant_role = discord.utils.get(self.css_guild.roles, name="Applicant")
+
+        return self._applicant_role
 
     @property
     def roles_channel(self) -> discord.TextChannel | None:


### PR DESCRIPTION
Now when /induct <user> is called, it will remove the Applicant role from the user.
If they didn't have the applicant role, then it works fine too.

Outputs a warning if the applicant role doesn't exist and errors if /induct is called when it doesn't exist, with a new error code.

Bot.applicant_role can be used to get the applicant role, might be worth moving the error handling into them, and make them always return a role, rather than have to check every time a role is requested, but that's an issue for a different PR.

Resolves #4 