### PR TITLE
Fix bot token regex.

### DIFF
--- a/config.py
+++ b/config.py
@@ -72,7 +72,7 @@ class Settings(metaclass=SettingsMeta):
             dotenv.load_dotenv()
 
             discord_bot_token: str = os.getenv("DISCORD_BOT_TOKEN", "")
-            if not discord_bot_token or not re.match(r"\A([A-Za-z0-9]{24,26})\.([A-Za-z0-9]{6})\.([A-Za-z0-9_-]{27,38})\Z", discord_bot_token):
+            if not discord_bot_token or not re.match(r"\A([A-Za-z0-9]{24,26})\.([A-Za-z0-9_]{6})\.([A-Za-z0-9_-]{27,38})\Z", discord_bot_token):
                 raise ImproperlyConfigured("DISCORD_BOT_TOKEN must be a valid Discord bot token (see https://discord.com/developers/docs/topics/oauth2#bot-vs-user-accounts).")
             cls._settings["DISCORD_BOT_TOKEN"] = discord_bot_token
 


### PR DESCRIPTION
When testing, I made a token that had an underscore in the middle section, which the regex rejected.
I don't know if they (and hyphens) can be in the first section, but I didn't generate any tokens with one in there.