### PR TITLE
/induct removes applicant role from user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Users of the bot may encounter error codes when attempting to execute slash-comm
 * `E1022` - The CSS Discord server does not contain a role with the name "Guest" (required for the `/induct`, `/makemember`, `/stats` & `/archive` commands and the `kick_no_introduction_members` & `introduction_reminder` tasks)
 * `E1023` - The CSS Discord server does not contain a role with the name "Member" (required for the `/makemember` command)
 * `E1024` - The CSS Discord server does not contain a role with the name "Archivist" (required for the `/archive` command)
+* `E1025` - The CSS Discord server does not contain a role with the name "Applicant" (required for the `/induct` command)
 * `E1031` - The CSS Discord server does not contain a text channel with the name "#roles" (required for the `/writeroles` command)
 * `E1032` - The CSS Discord server does not contain a text channel with the name "#general" (required for the `/induct` command)
 * `E1041` - The guild member IDs could not be retrieved from the MEMBERS_PAGE_URL

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Users of the bot may encounter error codes when attempting to execute slash-comm
 * `E1022` - The CSS Discord server does not contain a role with the name "Guest" (required for the `/induct`, `/makemember`, `/stats` & `/archive` commands and the `kick_no_introduction_members` & `introduction_reminder` tasks)
 * `E1023` - The CSS Discord server does not contain a role with the name "Member" (required for the `/makemember` command)
 * `E1024` - The CSS Discord server does not contain a role with the name "Archivist" (required for the `/archive` command)
-* `E1025` - The CSS Discord server does not contain a role with the name "Applicant" (required for the `/induct` command)
+* `E1025` - The CSS Discord server does not contain a role with the name "Applicant" (enhances the `/induct` command)
 * `E1031` - The CSS Discord server does not contain a text channel with the name "#roles" (required for the `/writeroles` command)
 * `E1032` - The CSS Discord server does not contain a text channel with the name "#general" (required for the `/induct` command)
 * `E1041` - The guild member IDs could not be retrieved from the MEMBERS_PAGE_URL

--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -22,7 +22,7 @@ import utils
 from cogs.utils import TeXBotAutocompleteContext, TeXBotCog
 from config import settings
 from db.core.models import DiscordReminder, LeftMember, UoBMadeMember
-from exceptions import ArchivistRoleDoesNotExist, CommitteeRoleDoesNotExist, GeneralChannelDoesNotExist, GuestRoleDoesNotExist, GuildDoesNotExist, MemberRoleDoesNotExist, RolesChannelDoesNotExist
+from exceptions import ApplicantRoleDoesNotExist, ArchivistRoleDoesNotExist, CommitteeRoleDoesNotExist, GeneralChannelDoesNotExist, GuestRoleDoesNotExist, GuildDoesNotExist, MemberRoleDoesNotExist, RolesChannelDoesNotExist
 from utils import TeXBot
 
 
@@ -113,6 +113,16 @@ class ApplicationCommandsCog(TeXBotCog):
                 logging_message=str(CommitteeRoleDoesNotExist())
             )
             return
+        
+        applicant_role: discord.Role | None = self.bot.applicant_role
+        if not applicant_role:
+            await self.send_error(
+                ctx,
+                error_code="E1025",
+                command_name="induct",
+                logging_message=str(ApplicantRoleDoesNotExist())
+            )
+            return
 
         interaction_member: discord.Member | None = guild.get_member(ctx.user.id)
         if not interaction_member:
@@ -170,6 +180,11 @@ class ApplicationCommandsCog(TeXBotCog):
             await general_channel.send(
                 f"""{random.choice(settings["WELCOME_MESSAGES"]).replace("<User>", induction_member.mention).strip()} :tada:\nRemember to grab your roles in {roles_channel_mention} and say hello to everyone here! :wave:"""
             )
+
+        await induction_member.remove_roles(
+            applicant_role,  # type: ignore
+            reason=f"{ctx.user} used TeX Bot slash-command: \"/induct\""
+        )
 
         await induction_member.add_roles(
             guest_role,  # type: ignore

--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -115,14 +115,6 @@ class ApplicationCommandsCog(TeXBotCog):
             return
         
         applicant_role: discord.Role | None = self.bot.applicant_role
-        if not applicant_role:
-            await self.send_error(
-                ctx,
-                error_code="E1025",
-                command_name="induct",
-                logging_message=str(ApplicantRoleDoesNotExist())
-            )
-            return
 
         interaction_member: discord.Member | None = guild.get_member(ctx.user.id)
         if not interaction_member:
@@ -181,10 +173,11 @@ class ApplicationCommandsCog(TeXBotCog):
                 f"""{random.choice(settings["WELCOME_MESSAGES"]).replace("<User>", induction_member.mention).strip()} :tada:\nRemember to grab your roles in {roles_channel_mention} and say hello to everyone here! :wave:"""
             )
 
-        await induction_member.remove_roles(
-            applicant_role,  # type: ignore
-            reason=f"{ctx.user} used TeX Bot slash-command: \"/induct\""
-        )
+        if applicant_role:
+            await induction_member.remove_roles(
+                applicant_role,  # type: ignore
+                reason=f"{ctx.user} used TeX Bot slash-command: \"/induct\""
+            )
 
         await induction_member.add_roles(
             guest_role,  # type: ignore

--- a/exceptions.py
+++ b/exceptions.py
@@ -274,7 +274,7 @@ class ApplicantRoleDoesNotExist(RoleDoesNotExist):
 
     def __init__(self, message: str | None = None) -> None:
         # noinspection SpellCheckingInspection
-        super().__init__(message, role_name="Applicant", dependant_commands={"induct"})
+        super().__init__(message, role_name="Applicant")
 
 
 class ChannelDoesNotExist(BaseDoesNotExistError):

--- a/exceptions.py
+++ b/exceptions.py
@@ -266,6 +266,17 @@ class ArchivistRoleDoesNotExist(RoleDoesNotExist):
         super().__init__(message, role_name="Archivist", dependant_commands={"archive"})
 
 
+class ApplicantRoleDoesNotExist(RoleDoesNotExist):
+    """
+        Exception class to raise when the required Discord role with the name
+        "Member" does not exist.
+    """
+
+    def __init__(self, message: str | None = None) -> None:
+        # noinspection SpellCheckingInspection
+        super().__init__(message, role_name="Applicant", dependant_commands={"induct"})
+
+
 class ChannelDoesNotExist(BaseDoesNotExistError):
     """
         Exception class to raise when a required Discord channel with the given

--- a/messages.json
+++ b/messages.json
@@ -14,7 +14,7 @@
         "<User> just joined. Hide your bananas.",
         "<User> just arrived. Seems OP - please nerf.",
         "<User> just slid into the CSS server.",
-        "A <User> has spawned in the CSS server.",
+        "A <User> has spawned in the CCS server.",
         "Where’s <User>? In the CSS server!",
         "<User> hopped into the CSS server. Kangaroo!!",
         "<User> just showed up. Hold my beer.",
@@ -30,7 +30,7 @@
         "<User> is here, as the CSS prophecy foretold.",
         "<User> is here to kick CSS butt and chew bubblegum. And <User> is all out of gum.",
         "Hello. Is it <User> you're looking for?",
-        "Roses are red, violets are blue, <User> joined the CSS server for you",
+        "Roses are red, violets are blue, <User> joined the CCS server for you",
         "Hey <User>, welcome to CSS!"
     ],
     "roles_messages": [

--- a/messages.json
+++ b/messages.json
@@ -14,7 +14,7 @@
         "<User> just joined. Hide your bananas.",
         "<User> just arrived. Seems OP - please nerf.",
         "<User> just slid into the CSS server.",
-        "A <User> has spawned in the CCS server.",
+        "A <User> has spawned in the CSS server.",
         "Where’s <User>? In the CSS server!",
         "<User> hopped into the CSS server. Kangaroo!!",
         "<User> just showed up. Hold my beer.",
@@ -30,7 +30,7 @@
         "<User> is here, as the CSS prophecy foretold.",
         "<User> is here to kick CSS butt and chew bubblegum. And <User> is all out of gum.",
         "Hello. Is it <User> you're looking for?",
-        "Roses are red, violets are blue, <User> joined the CCS server for you",
+        "Roses are red, violets are blue, <User> joined the CSS server for you",
         "Hey <User>, welcome to CSS!"
     ],
     "roles_messages": [

--- a/utils.py
+++ b/utils.py
@@ -201,6 +201,7 @@ class TeXBot(discord.Bot):
         self._guest_role: discord.Role | None = None
         self._member_role: discord.Role | None = None
         self._archivist_role: discord.Role | None = None
+        self._applicant_role: discord.Role | None = None
         self._roles_channel: discord.TextChannel | None = None
         self._general_channel: discord.TextChannel | None = None
         self._welcome_channel: discord.TextChannel | None = None
@@ -241,6 +242,13 @@ class TeXBot(discord.Bot):
             self._archivist_role = discord.utils.get(self.css_guild.roles, name="Archivist")
 
         return self._archivist_role
+    
+    @property
+    def applicant_role(self) -> discord.Role | None:
+        if not self._applicant_role or not discord.utils.get(self.css_guild.roles, id=self._applicant_role.id):
+            self._applicant_role = discord.utils.get(self.css_guild.roles, name="Applicant")
+
+        return self._applicant_role
 
     @property
     def roles_channel(self) -> discord.TextChannel | None:


### PR DESCRIPTION
Let's try this again
Redo of #5, I read somewhere it was fine to delete the repo once it was in a PR, but I guess not.

Warns if no Applicant role exists on startup
Ignores if no Applicant role exists when using /induct
Removes Applicant from user if the role exists when using /induct
(It's safe to try to remove a role a user doesn't have)