### PR TITLE
Fix shell=True security issues & reference script by module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unreachable = true
 django_settings_module = "db.settings"
 
 [tool.ruff]
-select = ["E", "F", "W", "C", "I", "N", "D"]
+select = ["E", "F", "W", "C", "I", "N", "D", "S"]
 ignore = ["N818", "N806", "D203", "D212"]
 line-length = 95
 unfixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,10 @@ django_settings_module = "db.settings"
 
 [tool.ruff]
 select = ["E", "F", "W", "C", "I", "N", "D", "S"]
-ignore = ["N818", "N806", "D203", "D212"]
+ignore = ["N818", "N806", "D203", "D212", "S101", "S311"]
 line-length = 95
 unfixable = ["ALL"]
+#fixable = ["E501"]
 target-version ="py311"
 task-tags = [
     "TODO",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ select = ["E", "F", "W", "C", "I", "N", "D", "S"]
 ignore = ["N818", "N806", "D203", "D212", "S101", "S311"]
 line-length = 95
 unfixable = ["ALL"]
-#fixable = ["E501"]
 target-version ="py311"
 task-tags = [
     "TODO",

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -119,7 +119,6 @@ class BaseTestArgumentParser:
 
         The command line outputs are stored in class variables for later access.
         """
-        # NOTE: Because executing utils.py from a command-line subprocess requires it to be spawned as a shell, security issues can occur. Therefore loose validation checks are required for the values of util_function_name & arguments (see https://stackoverflow.com/a/29023432/14403974)
         if not re.match(r"\A[a-zA-Z0-9._\-+!\"' ]*\Z", util_function_name):
             raise TypeError(
                 "util_function_name must be a valid function name for"
@@ -145,14 +144,13 @@ class BaseTestArgumentParser:
         else:
             raise FileNotFoundError("Could not locate project root directory.")
 
-        subprocess_args: list[str] = [sys.executable, "utils.py"]
+        subprocess_args: list[str] = [sys.executable, "-m", "utils"]
         if util_function_name:
             subprocess_args.append(util_function_name)
         subprocess_args.extend(arguments)
 
         parser_output: CompletedProcess[bytes] = subprocess.run(
-            " ".join(subprocess_args),
-            shell=True,
+            subprocess_args,  # noqa: S603
             cwd=project_root.parent,
             capture_output=True
         )


### PR DESCRIPTION
Don't use shell=True when opening a subprocess (https://beta.ruff.rs/docs/rules/subprocess-popen-with-shell-equals-true/)