### PR TITLE
Log major error exceptions

### DIFF
--- a/cogs/events.py
+++ b/cogs/events.py
@@ -88,6 +88,16 @@ class EventsCog(TeXBotCog):
         logging.info("Ready! Logged in as %s", self.bot.user)
 
     @TeXBotCog.listener()
+    async def on_application_command_error(self, ctx: discord.ApplicationContext, error: discord.DiscordException) -> None:  # noqa: E501
+        """Log any major command errors in the logging channel & stderr."""
+        await self.bot.send_error(
+            ctx,
+            message="Please contact a committee member.",
+            command_name=ctx.command.qualified_name,
+            logging_message=str(error)
+        )
+
+    @TeXBotCog.listener()
     async def on_member_update(self, before: discord.Member, after: discord.Member) -> None:
         """
         Send a welcome message to this member's DMs & remove introduction reminder flags.

--- a/config.py
+++ b/config.py
@@ -395,7 +395,7 @@ class Settings:
             # noinspection SpellCheckingInspection
             logging.basicConfig(
                 level=getattr(logging, console_log_level),
-                format="%(levelname)s | %(module)s: %(message)s"
+                format="%(levelname)s: %(message)s"
             )
 
             self._is_env_variables_setup = True

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 """Utility classes & functions provided for use across the whole of the project."""
 
+import logging
 import os
 import re
 import sys
@@ -11,6 +12,7 @@ import discord
 if __name__ != "__main__":
     import io
     import math
+    from collections.abc import Mapping
     from typing import TYPE_CHECKING, Any, Final, TypeAlias
 
     import matplotlib.pyplot as plt
@@ -182,6 +184,22 @@ if __name__ != "__main__":
         CSS Discord Server, while also raising the correct errors if these objects do not
         exist.
         """
+
+        ERROR_ACTIVITIES: Final[Mapping[str, str]] = {
+            "ping": "reply to ping",
+            "write_roles": "send messages",
+            "edit_message": "edit the message",
+            "induct": "induct user",
+            "make_member": "make you a member",
+            "remind_me": "remind you",
+            "channel_stats": "display channel statistics",
+            "server_stats": "display whole server statistics",
+            "user_stats": "display your statistics",
+            "left_member_stats": (
+                "display statistics about the members that have left the server"
+            ),
+            "archive": "archive the selected category"
+        }
 
         def __init__(self, *args: Any, **options: Any) -> None:
             """Initialize a new discord.Bot subclass with empty shortcut accessors."""
@@ -355,6 +373,61 @@ if __name__ != "__main__":
 
             self._css_guild = css_guild
             self._css_guild_set = True
+
+        async def send_error(self, ctx: discord.ApplicationContext, error_code: str | None = None, command_name: str | None = None, message: str | None = None, logging_message: str | None = None) -> None:  # noqa: E501
+            """
+            Construct & format an error message from the given details.
+
+            The constructed error message is then sent as the response to the given
+            application command context.
+            """
+            construct_error_message: str = ":warning:There was an error"
+            construct_logging_error_message: str = ""
+
+            if error_code:
+                committee_mention: str = "committee"
+
+                committee_role: discord.Role | None = await self.committee_role
+                if committee_role:
+                    committee_mention = committee_role.mention
+
+                construct_error_message = (
+                        f"**Contact a {committee_mention} member, referencing error code:"
+                        f" {error_code}**\n"
+                        + construct_error_message
+                )
+
+                construct_logging_error_message += f"{error_code} :"
+
+            if command_name:
+                construct_error_message += (
+                    f" when trying to {self.ERROR_ACTIVITIES[command_name]}"
+                )
+
+                if construct_logging_error_message:
+                    construct_logging_error_message += " "
+                construct_logging_error_message += f"({command_name})"
+
+            if message:
+                construct_error_message += ":"
+            else:
+                construct_error_message += "."
+
+            construct_error_message += ":warning:"
+
+            if message:
+                message = re.sub(
+                    r"<([@&#]?|(@[&#])?)\d+>",
+                    lambda match: f"`{match.group(0)}`", message.strip()
+                )
+                construct_error_message += f"\n`{message}`"
+
+            await ctx.respond(construct_error_message, ephemeral=True)
+
+            if logging_message:
+                if construct_logging_error_message:
+                    construct_logging_error_message += " "
+                logging.error("%s%s", construct_logging_error_message, logging_message)
 
 if __name__ == "__main__":
     arg_parser: ArgumentParser = ArgumentParser(


### PR DESCRIPTION
When unhandled exceptions are raised by a failing command, a suitable error message will be sent to the use then the error will be logged (both to stderr and the Discord webhook logging channel)