### PR TITLE
Rename core DB file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ __pycache__
 # Local files
 local/
 *.sqlite3
+*.db

--- a/db/settings.py
+++ b/db/settings.py
@@ -37,7 +37,7 @@ MIDDLEWARE = ["django.middleware.common.CommonMiddleware"]
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "NAME": BASE_DIR / "core.db",
     }
 }
 


### PR DESCRIPTION
As confirmed by [this](https://stackoverflow.com/a/808535/14403974) StackOverflow answer, the database file should not broadcast which schema is used and as such should be renamed to `core.db`.