### PR TITLE
Revert "Add the message content intent"

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,6 @@ with SuppressTraceback():
     intents: discord.Intents = discord.Intents.default()
     # noinspection PyDunderSlots,PyUnresolvedReferences
     intents.members = True
-    intents.message_content = True
 
     bot = TeXBot(intents=intents)
 


### PR DESCRIPTION
Reverts CSSUoB/TeX-Bot-Py-V2#109

This intent is not required for the bot and was incorrectly added by some committee members who were being too frivolous with their pull request reviews.

I would like to personally apologise to members who may have been affected. TeXBot will never *intentionally* access your message contents.