### PR TITLE
Improve `GROUP_NAME` Env variable referencing & documentation

### DIFF
--- a/cogs/command_error.py
+++ b/cogs/command_error.py
@@ -38,7 +38,7 @@ class CommandErrorCog(TeXBotBaseCog):
         elif isinstance(error, CheckAnyFailure):
             if CommandChecks.is_interaction_user_in_main_guild_failure(error.checks[0]):
                 message = (
-                    f"You must be a member of the {self.bot.group_name} Discord guild "
+                    f"You must be a member of the {self.bot.group_short_name} Discord server "
                     "to use this command."
                 )
 

--- a/cogs/induct.py
+++ b/cogs/induct.py
@@ -102,7 +102,7 @@ class InductSendMessageCog(TeXBotBaseCog):
                 user_type = "member"
 
         await after.send(
-            f"**Congrats on joining the {self.bot.group_name} Discord server "
+            f"**Congrats on joining the {self.bot.group_short_name} Discord server "
             f"as a {user_type}!** "
             "You now have access to communicate in all the public channels.\n\n"
             "Some things to do to get started:\n"
@@ -117,14 +117,13 @@ class InductSendMessageCog(TeXBotBaseCog):
             # TODO @CarrotManMatt: Remove environment variables that are only used in messages. Messages will be extracted into the external JSON file.  # noqa: FIX002
             # https://github.com/CSSUoB/TeX-Bot-Py-V2/issues/90
             await after.send(
-                f"You can also get yourself an annual membership to {self.bot.group_name} "
-                f"for only £5! "
+                f"You can also get yourself an annual membership "
+                f"to {self.bot.group_full_name} for only £5! "
                 f"""Just head to {settings["PURCHASE_MEMBERSHIP_URL"]}. """
                 "You'll get awesome perks like a free T-shirt:shirt:, "
                 "access to member only events:calendar_spiral: "
-                "& a cool green name "
-                f"on the {self.bot.group_name} Discord server:green_square:! "
-                f"""Checkout all the perks at {settings["MEMBERSHIP_PERKS_URL"]}"""
+                f"& a cool green name on the {self.bot.group_short_name} Discord server"
+                f":green_square:! Checkout all the perks at {settings["MEMBERSHIP_PERKS_URL"]}"
             )
 
 
@@ -167,7 +166,7 @@ class BaseInductCog(TeXBotBaseCog):
             )
 
         if "<Purchase_Membership_URL>" in random_welcome_message:
-            random_welcome_message.replace("<Group_Name>", self.bot.group_name)
+            random_welcome_message.replace("<Group_Name>", self.bot.group_short_name)
 
         return random_welcome_message.strip()
 

--- a/cogs/make_member.py
+++ b/cogs/make_member.py
@@ -29,7 +29,7 @@ class MakeMemberCommandCog(TeXBotBaseCog):
         f"""{
             "Student"
             if (
-                "_GROUP_FULL_NAME" in settings
+                settings["_GROUP_FULL_NAME"]
                 and (
                     "computer science society" in settings["_GROUP_FULL_NAME"]
                     or "css" in settings["_GROUP_FULL_NAME"]
@@ -66,7 +66,7 @@ class MakeMemberCommandCog(TeXBotBaseCog):
             f"""Your UoB Student {
                 "UoB Student"
                 if (
-                    "_GROUP_FULL_NAME" in settings
+                    settings["_GROUP_FULL_NAME"]
                     and (
                         "computer science society" in settings["_GROUP_FULL_NAME"]
                         or "css" in settings["_GROUP_FULL_NAME"]

--- a/cogs/make_member.py
+++ b/cogs/make_member.py
@@ -29,8 +29,18 @@ class MakeMemberCommandCog(TeXBotBaseCog):
         f"""{
             "Student"
             if (
-                settings["_GROUP_NAME"].lower() in ("css", "computer science society")
-                or "uob" in settings["_GROUP_NAME"].lower()
+                "_GROUP_FULL_NAME" in settings
+                and (
+                    "computer science society" in settings["_GROUP_FULL_NAME"]
+                    or "css" in settings["_GROUP_FULL_NAME"]
+                    or "uob" in settings["_GROUP_FULL_NAME"]
+                    or "university of birmingham" in settings["_GROUP_FULL_NAME"]
+                    or "uob" in settings["_GROUP_FULL_NAME"]
+                    or (
+                        "bham" in settings["_GROUP_FULL_NAME"]
+                        and "uni" in settings["_GROUP_FULL_NAME"]
+                    )
+                )
             )
             else "Member"
         } ID"""
@@ -56,8 +66,18 @@ class MakeMemberCommandCog(TeXBotBaseCog):
             f"""Your UoB Student {
                 "UoB Student"
                 if (
-                    settings["_GROUP_NAME"].lower() in ("css", "computer science society")
-                    or "uob" in settings["_GROUP_NAME"].lower()
+                    "_GROUP_FULL_NAME" in settings
+                    and (
+                        "computer science society" in settings["_GROUP_FULL_NAME"]
+                        or "css" in settings["_GROUP_FULL_NAME"]
+                        or "uob" in settings["_GROUP_FULL_NAME"]
+                        or "university of birmingham" in settings["_GROUP_FULL_NAME"]
+                        or "uob" in settings["_GROUP_FULL_NAME"]
+                        or (
+                            "bham" in settings["_GROUP_FULL_NAME"]
+                            and "uni" in settings["_GROUP_FULL_NAME"]
+                        )
+                    )
                 )
                 else "Member"
             } ID"""
@@ -185,7 +205,7 @@ class MakeMemberCommandCog(TeXBotBaseCog):
                     "to use this command.\n"
                     f"The provided {self.GROUP_MEMBER_ID_ARGUMENT_NAME} must match "
                     f"the {self.bot.group_member_id_type} ID "
-                    f"that you purchased your {self.bot.group_name} membership with."
+                    f"that you purchased your {self.bot.group_short_name} membership with."
                 )
             )
             return

--- a/cogs/send_get_roles_reminders.py
+++ b/cogs/send_get_roles_reminders.py
@@ -154,7 +154,8 @@ class SendGetRolesRemindersTaskCog(TeXBotBaseCog):
                 continue
 
             await member.send(
-                f"Hey! It seems like you joined the {self.bot.group_name} Discord server "
+                "Hey! It seems like you joined "
+                f"the {self.bot.group_short_name} Discord server "
                 "and have been given the `@Guest` role but have not yet nabbed yourself any "
                 f"opt-in roles.\nYou can head to {roles_channel_mention} "
                 "and click on the icons to get optional roles like pronouns "

--- a/cogs/send_introduction_reminders.py
+++ b/cogs/send_introduction_reminders.py
@@ -229,7 +229,8 @@ class SendIntroductionRemindersTaskCog(TeXBotBaseCog):
                 await self.send_error(
                     interaction,
                     message=(
-                        f"You must be a member of the {self.bot.group_short_name} Discord server "
+                        f"You must be a member "
+                        f"of the {self.bot.group_short_name} Discord server "
                         f"""to opt{
                             "-out of" if button_will_make_opt_out else " back in to"
                         } introduction reminders."""

--- a/cogs/send_introduction_reminders.py
+++ b/cogs/send_introduction_reminders.py
@@ -134,7 +134,7 @@ class SendIntroductionRemindersTaskCog(TeXBotBaseCog):
                 await member.send(
                     content=(
                         "Hey! It seems like you joined "
-                        f"the {self.bot.group_name} Discord server "
+                        f"the {self.bot.group_short_name} Discord server "
                         "but have not yet introduced yourself.\n"
                         "You will only get access to the rest of the server after sending "
                         "an introduction message."
@@ -229,7 +229,7 @@ class SendIntroductionRemindersTaskCog(TeXBotBaseCog):
                 await self.send_error(
                     interaction,
                     message=(
-                        f"You must be a member of the {self.bot.group_name} Discord server "
+                        f"You must be a member of the {self.bot.group_short_name} Discord server "
                         f"""to opt{
                             "-out of" if button_will_make_opt_out else " back in to"
                         } introduction reminders."""

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -7,7 +7,7 @@ __all__: Sequence[str] = ("amount_of_time_formatter", "plot_bar_chart", "StatsCo
 import io
 import math
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import discord
 import matplotlib.pyplot as plt
@@ -135,15 +135,30 @@ def plot_bar_chart(data: dict[str, int], x_label: str, y_label: str, title: str,
 class StatsCommandsCog(TeXBotBaseCog):
     """Cog class that defines the "/stats" command group and its command call-back methods."""
 
+    _DISCORD_SERVER_NAME: Final[str] = f"""{
+        "the " if (
+            (
+                settings["_GROUP_SHORT_NAME"]
+            ).replace("the", "").replace("THE", "").replace("The", "").strip()
+        )
+        else ""
+    }{
+        (
+            (
+                settings["_GROUP_SHORT_NAME"]
+            ).replace("the", "").replace("THE", "").replace("The", "").strip()
+        )
+        if (
+            (
+                settings["_GROUP_SHORT_NAME"]
+            ).replace("the", "").replace("THE", "").replace("The", "").strip()
+        )
+        else "our community group's"
+    } Discord server"""
+
     stats: discord.SlashCommandGroup = discord.SlashCommandGroup(
         "stats",
-        (
-            f"""Various statistics about {
-                "the " if settings["_GROUP_NAME"] else ""
-            }{
-                settings["_GROUP_NAME"] if settings["_GROUP_NAME"] else "our community group's"
-            } Discord server"""
-        )
+        f"Various statistics about {_DISCORD_SERVER_NAME}"
     )
 
     # noinspection SpellCheckingInspection
@@ -271,13 +286,7 @@ class StatsCommandsCog(TeXBotBaseCog):
 
     @stats.command(
         name="server",
-        description=(
-            f"""Displays the stats for the whole of {
-                "the " if settings["_GROUP_NAME"] else ""
-            }{
-                settings["_GROUP_NAME"] if settings["_GROUP_NAME"] else "our community group's"
-            } Discord server"""
-        )
+        description=f"Displays the stats for the whole of {_DISCORD_SERVER_NAME}"
     )
     async def server_stats(self, ctx: TeXBotApplicationContext) -> None:
         """
@@ -370,11 +379,13 @@ class StatsCommandsCog(TeXBotBaseCog):
                         )
                         })"""
                     ),
-                    title=f"Most Active Roles in the {self.bot.group_name} Discord Server",
+                    title=(
+                        f"Most Active Roles in the {self.bot.group_short_name} Discord Server"
+                    ),
                     filename="roles_server_stats.png",
                     description=(
                         "Bar chart of the number of messages sent by different roles "
-                        f"in the {self.bot.group_name} Discord server."
+                        f"in the {self.bot.group_short_name} Discord server."
                     ),
                     extra_text=(
                         "Messages sent by members with multiple roles are counted once "
@@ -393,11 +404,14 @@ class StatsCommandsCog(TeXBotBaseCog):
                             )
                         })"""
                     ),
-                    title=f"Most Active Channels in the {self.bot.group_name} Discord Server",
+                    title=(
+                        "Most Active Channels "
+                        f"in the {self.bot.group_short_name} Discord Server"
+                    ),
                     filename="channels_server_stats.png",
                     description=(
                         "Bar chart of the number of messages sent in different text channels "
-                        f"in the {self.bot.group_name} Discord server."
+                        f"in the {self.bot.group_short_name} Discord server."
                     )
                 ),
             ]
@@ -425,7 +439,7 @@ class StatsCommandsCog(TeXBotBaseCog):
                 ctx,
                 message=(
                     "You must be inducted as a guest member "
-                    f"of the {self.bot.group_name} Discord server to use this command."
+                    f"of the {self.bot.group_short_name} Discord server to use this command."
                 )
             )
             return
@@ -477,11 +491,14 @@ class StatsCommandsCog(TeXBotBaseCog):
                         )
                     })"""
                 ),
-                title=f"Your Most Active Channels in the {self.bot.group_name} Discord Server",
+                title=(
+                    "Your Most Active Channels "
+                    f"in the {self.bot.group_short_name} Discord Server"
+                ),
                 filename=f"{ctx.user}_stats.png",
                 description=(
                     f"Bar chart of the number of messages sent by {ctx.user} "
-                    f"in different channels in the {self.bot.group_name} Discord server."
+                    f"in different channels in the {self.bot.group_short_name} Discord server."
                 )
             )
         )
@@ -489,13 +506,7 @@ class StatsCommandsCog(TeXBotBaseCog):
     # noinspection SpellCheckingInspection
     @stats.command(
         name="leftmembers",
-        description=(
-            f"""Displays the stats about members that have left {
-                "the " if settings["_GROUP_NAME"] else ""
-            }{
-                settings["_GROUP_NAME"] if settings["_GROUP_NAME"] else "our community group's"
-            } Discord server"""
-        )
+        description=f"Displays the stats about members that have left {_DISCORD_SERVER_NAME}"
     )
     async def left_member_stats(self, ctx: TeXBotApplicationContext) -> None:
         """
@@ -549,16 +560,16 @@ class StatsCommandsCog(TeXBotBaseCog):
                 x_label="Role Name",
                 y_label=(
                     "Number of Members that have left "
-                    f"the {self.bot.group_name} Discord Server"
+                    f"the {self.bot.group_short_name} Discord Server"
                 ),
                 title=(
                     "Most Common Roles that Members had when they left "
-                    f"the {self.bot.group_name} Discord Server"
+                    f"the {self.bot.group_short_name} Discord Server"
                 ),
                 filename="left_members_stats.png",
                 description=(
                     "Bar chart of the number of members with different roles "
-                    f"that have left the {self.bot.group_name} Discord server."
+                    f"that have left the {self.bot.group_short_name} Discord server."
                 ),
                 extra_text=(
                     "Members that left with multiple roles "

--- a/cogs/strike.py
+++ b/cogs/strike.py
@@ -211,7 +211,7 @@ class BaseStrikeCog(TeXBotBaseCog):
         includes_ban_message: str = (
             (
                 "\nBecause you now have been given 3 strikes, you have been banned from "
-                f"the {self.bot.group_name} Discord server "
+                f"the {self.bot.group_short_name} Discord server "
                 f"and we have contacted {self.bot.group_moderation_contact} for "
                 "further action & advice."
             )
@@ -227,12 +227,12 @@ class BaseStrikeCog(TeXBotBaseCog):
 
         await strike_user.send(
             "Hi, a recent incident occurred in which you may have broken one or more of "
-            f"the {self.bot.group_name} Discord server's rules.\n"
+            f"the {self.bot.group_short_name} Discord server's rules.\n"
             "We have increased the number of strikes associated with your account "
             f"to {actual_strike_amount} and "
             "the corresponding moderation action will soon be applied to you. "
             "To find what moderation action corresponds to which strike level, "
-            f"you can view the {self.bot.group_name} Discord server moderation document "
+            f"you can view the {self.bot.group_short_name} Discord server moderation document "
             f"[here](<{settings.MODERATION_DOCUMENT_URL}>)\nPlease ensure you have read "
             f"the rules in {rules_channel_mention} so that your future behaviour adheres "
             f"to them.{includes_ban_message}\n\nA committee member will be in contact "

--- a/cogs/write_roles.py
+++ b/cogs/write_roles.py
@@ -34,7 +34,7 @@ class WriteRolesCommandCog(TeXBotBaseCog):
         roles_message: str
         for roles_message in settings["ROLES_MESSAGES"]:
             await roles_channel.send(
-                roles_message.replace("<Group_Name>", self.bot.group_name)
+                roles_message.replace("<Group_Name>", self.bot.group_short_name)
             )
 
         await ctx.respond("All messages sent successfully.", ephemeral=True)

--- a/config.py
+++ b/config.py
@@ -179,17 +179,29 @@ class Settings:
             raise ImproperlyConfigured(INVALID_WEBHOOK_URL_MESSAGE)
         self._settings["DISCORD_LOG_CHANNEL_WEBHOOK_URL"] = discord_log_channel_webhook_url
 
-        group_name: str = os.getenv("GROUP_NAME", "")
-        group_name_is_valid: bool = bool(
-            not group_name
-            or re.match(r"\A[A-Za-z0-9 '&!?:,.#%\"-]+\Z", group_name)
+        group_full_name: str = os.getenv("GROUP_NAME", "")
+        group_full_name_is_valid: bool = bool(
+            not group_full_name
+            or re.match(r"\A[A-Za-z0-9 '&!?:,.#%\"-]+\Z", group_full_name)
         )
-        if not group_name_is_valid:
-            INVALID_GROUP_NAME: Final[str] = (
+        if not group_full_name_is_valid:
+            INVALID_GROUP_FULL_NAME: Final[str] = (
                 "GROUP_NAME must not contain any invalid characters."
             )
-            raise ImproperlyConfigured(INVALID_GROUP_NAME)
-        self._settings["_GROUP_NAME"] = group_name
+            raise ImproperlyConfigured(INVALID_GROUP_FULL_NAME)
+        self._settings["_GROUP_FULL_NAME"] = group_full_name
+
+        group_short_name: str = os.getenv("GROUP_SHORT_NAME", "")
+        group_short_name_is_valid: bool = bool(
+            not group_short_name
+            or re.match(r"\A[A-Za-z0-9'&!?:,.#%\"-]+\Z", group_short_name)
+        )
+        if not group_short_name_is_valid:
+            INVALID_GROUP_SHORT_NAME: Final[str] = (
+                "GROUP_SHORT_NAME must not contain any invalid characters."
+            )
+            raise ImproperlyConfigured(INVALID_GROUP_SHORT_NAME)
+        self._settings["_GROUP_SHORT_NAME"] = group_short_name
 
         purchase_membership_url: str = os.getenv("PURCHASE_MEMBERSHIP_URL", "")
         purchase_membership_url_is_valid: bool = bool(

--- a/example.env
+++ b/example.env
@@ -13,10 +13,14 @@ DISCORD_GUILD_ID=[Replace with the ID of the your Discord guild]
 # Must be a valid Discord channel webhook URL (see https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks)
 DISCORD_LOG_CHANNEL_WEBHOOK_URL=[Replace with your Discord log channel webhook URL]
 
-# The name of your community group.
+# The full name of your community group, do NOT use an abbreviation.
 # This is substituted into many error/welcome messages sent into your Discord guild, by the bot.
-# If this is not set the group name will be retrieved from the name of your group's Discord guild
-GROUP_NAME=[Replace with the name of your community group]
+# If this is not set the group-full-name will be retrieved from the name of your group's Discord guild
+GROUP_NAME=[Replace with the full name of your community group (not an abbreviation)]
+
+# The short colloquial name of your community group, it is recommended that you set this to be an abbreviation of your group's name.
+# If this is not set the group-short-name will be determined from your group's full name
+GROUP_SHORT_NAME=[Replace with the short colloquial name of your community group]
 
 # The URL of the page where guests can purchase a full membership to join your community group
 # Must be a valid URL

--- a/messages.json
+++ b/messages.json
@@ -5,7 +5,7 @@
         "A wild <User> appeared.",
         "<User> just arrived. Seems OP - please nerf.",
         "Challenger approaching - <User> has appeared!",
-        "<User> has joined the <Group_Name> server! It's super effective!",
+        "<User> has joined the <Group_Name> Discord server! It's super effective!",
         "It's <User>! Praise the sun!",
         "Never gonna give <User> up. Never gonna let <User> down.",
         "Ha! <User> has joined <Group_Name>! You activated my trap card!",
@@ -44,7 +44,7 @@
         "I forgot the niceties, you can call me TeX. Hiya Papaya, <User>!",
         "According to all known laws of aviation, there is no way a <User> should be able to fly. Its wings are too small to get its fat little body off the ground. The <User>, of course, flies anyway because <User> doesn't care what humans think is impossible.",
         "No one expects the <User> inquisition!",
-        "Freeze, <User>! This is TeX! You're sentenced to 3 years in the <Group_Name> server for illegally searching us up on the Student Guild website!",
+        "Freeze, <User>! This is TeX! You're sentenced to 3 years in the <Group_Name> Discord server for illegally searching us up on the Student Guild website!",
         "Looks like <User> stumbled into the not-so-secret hideout of <Group_Name>.",
         "The truth is <User>.... the game was rigged from the start.",
         "Did you ever hear the tragedy of Darth <User> the Wise? I thought not, it's not a story the lecturers would tell you."

--- a/utils/tex_bot.py
+++ b/utils/tex_bot.py
@@ -218,34 +218,59 @@ class TeXBot(discord.Bot):
         return self._rules_channel
 
     @property
-    def group_name(self) -> str:
+    def group_full_name(self) -> str:
         """
-        The name of your community group.
+        The full name of your community group.
 
         This is substituted into many error/welcome messages sent into your Discord guild,
         by the bot.
-        The group name is either retrieved from the provided environment variable,
+        The group-full-name is either retrieved from the provided environment variable,
         or automatically identified from the name of your group's Discord guild.
         """
-        group_name: Final[str | None] = settings["_GROUP_NAME"]
+        GROUP_FULL_NAME: Final[str | None] = settings["_GROUP_FULL_NAME"]
         return (
-            group_name
-            if group_name
+            GROUP_FULL_NAME
+            if GROUP_FULL_NAME
             else (
-                "CSS"
-                if self.main_guild.name.lower() == "computer science society"
+                "The Computer Science Society"
+                if (
+                    "computer science society" in self.main_guild.name.lower()
+                    or "css" in self.main_guild.name.lower()
+                )
                 else self.main_guild.name
             )
         )
 
     @property
-    def group_full_name(self) -> str:
-        """The full capitalised name of your community group."""
+    def group_short_name(self) -> str:
+        """
+        The short colloquial name of your community group.
+
+        This defaults to `TeXBot.group_full_name`,
+        if no group-short-name is provided/could not be determined.
+        """
+        GROUP_SHORT_NAME: Final[str | None] = settings["_GROUP_SHORT_NAME"]
         return (
-            "The Computer Science Society"
-            if self.group_name.lower() in ("css", "computer science society")
-            else self.group_name
-        )
+            GROUP_SHORT_NAME
+            if GROUP_SHORT_NAME
+            else (
+                "CSS"
+                if (
+                    "computer science society" in self.group_full_name.lower()
+                    or "css" in self.group_full_name.lower()
+                )
+                else self.group_full_name
+            )
+        ).replace(
+            "the",
+            ""
+        ).replace(
+            "THE",
+            ""
+        ).replace(
+            "The",
+            ""
+        ).strip()
 
     @property
     def group_member_id_type(self) -> str:
@@ -257,9 +282,15 @@ class TeXBot(discord.Bot):
         return (
             "UoB Student"
             if (
-                self.group_name.lower() in ("css", "computer science society")
-                or "uob" in self.group_name.lower()
-                or "birmingham" in self.group_name.lower()
+                "computer science society" in self.group_full_name.lower()
+                or "css" in self.group_full_name.lower()
+                or "uob" in self.group_full_name.lower()
+                or "university of birmingham" in self.group_full_name.lower()
+                or "uob" in self.group_full_name.lower()
+                or (
+                    "bham" in self.group_full_name.lower()
+                    and "uni" in self.group_full_name.lower()
+                )
             )
             else "community group"
         )
@@ -274,9 +305,15 @@ class TeXBot(discord.Bot):
         return (
             "the Guild of Students"
             if (
-                self.group_name.lower() in ("css", "computer science society")
-                or "uob" in self.group_name.lower()
-                or "birmingham" in self.group_name.lower()
+                "computer science society" in self.group_full_name.lower()
+                or "css" in self.group_full_name.lower()
+                or "uob" in self.group_full_name.lower()
+                or "university of birmingham" in self.group_full_name.lower()
+                or "uob" in self.group_full_name.lower()
+                or (
+                    "bham" in self.group_full_name.lower()
+                    and "uni" in self.group_full_name.lower()
+                )
             )
             else "our community moderators"
         )

--- a/utils/tex_bot.py
+++ b/utils/tex_bot.py
@@ -227,10 +227,9 @@ class TeXBot(discord.Bot):
         The group-full-name is either retrieved from the provided environment variable,
         or automatically identified from the name of your group's Discord guild.
         """
-        GROUP_FULL_NAME: Final[str | None] = settings["_GROUP_FULL_NAME"]
-        return (
-            GROUP_FULL_NAME
-            if GROUP_FULL_NAME
+        return (  # type: ignore[no-any-return]
+            settings["_GROUP_FULL_NAME"]
+            if settings["_GROUP_FULL_NAME"]
             else (
                 "The Computer Science Society"
                 if (
@@ -249,10 +248,9 @@ class TeXBot(discord.Bot):
         This defaults to `TeXBot.group_full_name`,
         if no group-short-name is provided/could not be determined.
         """
-        GROUP_SHORT_NAME: Final[str | None] = settings["_GROUP_SHORT_NAME"]
-        return (
-            GROUP_SHORT_NAME
-            if GROUP_SHORT_NAME
+        return (  # type: ignore[no-any-return]
+            settings["_GROUP_SHORT_NAME"]
+            if settings["_GROUP_SHORT_NAME"]
             else (
                 "CSS"
                 if (


### PR DESCRIPTION
Rename `TeXBot.group_name` to `TeXBot.full_group_name` & replace old `TeXBot.full_group_name` with `TeXBot.group_short_name`