### PR TITLE
Show logging messages after formatting

### DIFF
--- a/config.py
+++ b/config.py
@@ -147,10 +147,11 @@ class Settings(abc.ABC):
         console_logging_handler: logging.Handler = logging.StreamHandler()
         # noinspection SpellCheckingInspection
         console_logging_handler.setFormatter(
-            logging.Formatter("{asctime} - {name} - {levelname}", style="{")
+            logging.Formatter("{asctime} | {name} | {levelname:^8} - {message}", style="{")
         )
 
         logger.addHandler(console_logging_handler)
+        logger.propagate = False
 
     @classmethod
     def _setup_discord_bot_token(cls) -> None:


### PR DESCRIPTION
The format string for the current logging handler does not contain the actual logging message, so no message is output. This change fixes that.