### PR TITLE
Fix bug in determining Discord server name

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -137,7 +137,8 @@ class StatsCommandsCog(TeXBotBaseCog):
 
     _DISCORD_SERVER_NAME: Final[str] = f"""{
         "the " if (
-            (
+            settings["_GROUP_SHORT_NAME"] is not None
+            and (
                 settings["_GROUP_SHORT_NAME"]
             ).replace("the", "").replace("THE", "").replace("The", "").strip()
         )
@@ -149,7 +150,8 @@ class StatsCommandsCog(TeXBotBaseCog):
             ).replace("the", "").replace("THE", "").replace("The", "").strip()
         )
         if (
-            (
+            settings["_GROUP_SHORT_NAME"] is not None
+            and (
                 settings["_GROUP_SHORT_NAME"]
             ).replace("the", "").replace("THE", "").replace("The", "").strip()
         )


### PR DESCRIPTION
The internal `settings["_GROUP_SHORT_NAME"]` value may be null/`None` & the code determining the Discord server name in the description generator for the `stats` commands should handle this.