### PR TITLE
Fix resolving `PROJECT_ROOT` without using `gitpython`

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,7 +32,6 @@ from re import Match
 from typing import IO, Any, ClassVar, Final, final
 
 import dotenv
-import git
 import validators
 from django.core import management
 
@@ -41,6 +40,8 @@ from exceptions import (
     MessagesJSONFileMissingKeyError,
     MessagesJSONFileValueError,
 )
+
+PROJECT_ROOT: Final[Path] = Path(__file__).parent.resolve()
 
 TRUE_VALUES: Final[frozenset[str]] = frozenset({"true", "1", "t", "y", "yes", "on"})
 FALSE_VALUES: Final[frozenset[str]] = frozenset({"false", "0", "f", "n", "no", "off"})
@@ -301,17 +302,6 @@ class Settings(abc.ABC):
             raw_ping_command_easter_egg_probability
         )
 
-    @staticmethod
-    def _get_default_messages_json_file_path() -> Path:
-        PROJECT_ROOT: Final[str | git.PathLike | None] = (
-            git.Repo(".", search_parent_directories=True).working_tree_dir
-        )
-        if PROJECT_ROOT is None:
-            NO_ROOT_DIRECTORY_MESSAGE: Final[str] = "Could not locate project root directory."
-            raise FileNotFoundError(NO_ROOT_DIRECTORY_MESSAGE)
-
-        return PROJECT_ROOT / Path("messages.json")
-
     @classmethod
     @functools.lru_cache(maxsize=5)
     def _get_messages_dict(cls, raw_messages_file_path: str | None) -> Mapping[str, object]:
@@ -323,7 +313,7 @@ class Settings(abc.ABC):
         messages_file_path: Path = (
             Path(raw_messages_file_path)
             if raw_messages_file_path
-            else cls._get_default_messages_json_file_path()
+            else PROJECT_ROOT / Path("messages.json")
         )
 
         if not messages_file_path.is_file():

--- a/poetry.lock
+++ b/poetry.lock
@@ -1714,4 +1714,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "c8170ae2c83d8326c88ef0228ada8f4c7efd53730804089f0dc7b0282fcbeb5a"
+content-hash = "d157b5a756311a5319d8a881663c61a196eca8f9c9ce9586585b7b25704648d3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ django = "~4.2"
 matplotlib = "^3.8"
 mplcyberpunk = "^0.7"
 python-logging-discord-handler = "^0.1"
-gitpython = "^3.1"
 classproperties = {git = "https://github.com/hottwaj/classproperties.git"}
 setuptools = "^69.0"
 
@@ -46,6 +45,7 @@ django-stubs = {extras = ["compatible-mypy"], version = "~4.2"}
 types-beautifulsoup4 = "^4.12.0"
 pytest = "^7.4"
 ruff = "^0.1"
+gitpython = "^3.1"
 pymarkdownlnt = "^0.9"
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,6 +19,7 @@ import pytest
 from _pytest.capture import CaptureFixture, CaptureResult
 from classproperties import classproperty
 
+import config
 import utils
 from utils import InviteURLGenerator, UtilityFunction
 
@@ -149,32 +150,18 @@ class BaseTestArgumentParser:
         and the .env file in this project's root directory.
         """
 
-        @staticmethod
-        def _get_project_root() -> Path:
-            project_root: Path = Path(__file__).resolve()
-
-            for _ in range(8):
-                project_root = project_root.parent
-
-                if any(path.name.startswith("README.md") for path in project_root.iterdir()):
-                    return project_root
-
-            NO_ROOT_DIRECTORY_MESSAGE: Final[str] = "Could not locate project root directory."
-            raise FileNotFoundError(NO_ROOT_DIRECTORY_MESSAGE)
-
         def __init__(self, env_variable_name: str) -> None:
             """Store the current state of any instances of the stored environment variable."""
             self.env_variable_name: str = env_variable_name
-            self.PROJECT_ROOT: Final[Path] = self._get_project_root()
 
-            self.env_file_path: Path = self.PROJECT_ROOT / Path(".env")
+            self.env_file_path: Path = config.PROJECT_ROOT / Path(".env")
             self.old_env_value: str | None = os.environ.get(self.env_variable_name)
 
         def __enter__(self) -> None:
             """Delete all stored instances of the stored environment variable."""
             if self.env_file_path.is_file():
                 self.env_file_path = self.env_file_path.rename(
-                    self.PROJECT_ROOT / Path(".env.original")
+                    config.PROJECT_ROOT / Path(".env.original")
                 )
 
             if self.old_env_value is not None:
@@ -183,7 +170,7 @@ class BaseTestArgumentParser:
         def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType) -> None:  # noqa: E501
             """Restore the deleted environment variable to its previous states."""
             if self.env_file_path.is_file():
-                self.env_file_path.rename(self.PROJECT_ROOT / Path(".env"))
+                self.env_file_path.rename(config.PROJECT_ROOT / Path(".env"))
 
             if self.old_env_value is not None:
                 os.environ[self.env_variable_name] = self.old_env_value


### PR DESCRIPTION
When loaded into the runtime container, there is no git repo alongside the files. Thus an alternate solution from using the git repo is required to resolve/locate `PROJECT_ROOT`