### PR TITLE
Fix the shield badge query for retrieving the py-cord package version on `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Featured in the [CSS Discord guild](https://cssbham.com/discord).
 
 [![Current Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FCSSUoB%2FTeX-Bot-Py-V2%2Fmain%2Fpyproject.toml&query=%24.tool.poetry.version&label=TeX-Bot)](https://github.com/CSSUoB/TeX-Bot-Py-V2/tree/main)
 [![Python Version](https://img.shields.io/badge/Python-3.12-blue)](https://www.python.org/downloads/release/python-3116/)
-[![py-cord Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FCSSUoB%2FTeX-Bot-Py-V2%2Fmain%2Fpyproject.toml&query=%24.tool.poetry.dependencies%5B'py-cord-dev'%5D&label=py-cord)](https://pycord.dev/)
+[![py-cord Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FCSSUoB%2FTeX-Bot-Py-V2%2Fmain%2Fpyproject.toml&query=%24.tool.poetry.dependencies%5B%22py-cord%22%5D%5B%22rev%22%5D&label=py-cord)](https://pycord.dev/)
 [![Tests](https://github.com/CSSUoB/TeX-Bot-Py-V2/actions/workflows/tests.yaml/badge.svg)](https://github.com/CSSUoB/TeX-Bot-Py-V2/actions/workflows/tests.yaml)
 [![mypy passing](https://img.shields.io/badge/mypy-checked-%232EBB4E&label=mypy)](https://www.mypy-lang.org/)
 [![pymarkdown passing](https://img.shields.io/badge/pymarkdown-passing-%232EBB4E&label=pymarkdown)](https://github.com/jackdewinter/pymarkdown)


### PR DESCRIPTION
This will need to be changed *again* when py-cord returns to publishing their package on pypi.