### PR TITLE
Fix broken check at `on_member_remove` event

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -326,7 +326,7 @@ class StrikeTrackingError(BaseTeXBotError, RuntimeError):
         return "An error occurred while trying to track manually applied moderation actions."
 
 
-class NoAuditLogsStrikeTrackingError(StrikeTrackingError):
+class NoAuditLogsStrikeTrackingError(BaseTeXBotError, RuntimeError):
     """
     Exception class to raise when there are no audit logs to resolve the committee member.
 

--- a/utils/generate_invite_url.py
+++ b/utils/generate_invite_url.py
@@ -118,6 +118,7 @@ class InviteURLGenerator(UtilityFunction):
                 add_reactions=True,
                 use_slash_commands=True,
                 kick_members=True,
+                ban_members=True,
                 manage_channels=True,
                 view_audit_log=True
             ),


### PR DESCRIPTION
When this PR is merged any instances running in production will need to be re-invited, in order to update their permissions. Please use this command:

```shell
docker exec {TeXBot container name} poetry run python -m utils generate_invite_url {discord_bot_application_id}
```