### PR TITLE
Fix bug with retrieving audit log entries

### DIFF
--- a/cogs/send_get_roles_reminders.py
+++ b/cogs/send_get_roles_reminders.py
@@ -139,7 +139,7 @@ class SendGetRolesRemindersTaskCog(TeXBotBaseCog):
                         and guest_role in log.after.roles
                     )
                 )
-            except StopIteration:
+            except (StopIteration, StopAsyncIteration):
                 logger.error(  # noqa: TRY400
                     (
                         "Member with ID: %s could not be checked whether to send "


### PR DESCRIPTION
When retrieving audit log entries within `send_get_roles_reminders`, only `StopIteration` exception is excepted, whereas `StopAsyncIteration` should also be suppressed