### PR TITLE
Add note about why there is a seemingly superfluous check for whether the member is part of the guild

### DIFF
--- a/cogs/send_get_roles_reminders.py
+++ b/cogs/send_get_roles_reminders.py
@@ -149,7 +149,7 @@ class SendGetRolesRemindersTaskCog(TeXBotBaseCog):
                 if time_since_role_received <= datetime.timedelta(days=1):
                     continue
 
-            if member not in guild.members:  # HACK: Caching errors can cause the member to no longer be part of the guild, so this check must be performed before sending that member a message # noqa: FIX004
+            if member not in guild.members:  # HACK: Caching errors can cause the member to no longer be part of the guild at this point, so this check must be performed before sending that member a message # noqa: FIX004
                 logger.info(
                     (
                         "Member with ID: %s does not need to be sent a reminder "

--- a/cogs/send_get_roles_reminders.py
+++ b/cogs/send_get_roles_reminders.py
@@ -149,7 +149,7 @@ class SendGetRolesRemindersTaskCog(TeXBotBaseCog):
                 if time_since_role_received <= datetime.timedelta(days=1):
                     continue
 
-            if member not in guild.members:
+            if member not in guild.members:  # HACK: Caching errors can cause the member to no longer be part of the guild, so this check must be performed before sending that member a message # noqa: FIX004
                 logger.info(
                     (
                         "Member with ID: %s does not need to be sent a reminder "

--- a/cogs/send_introduction_reminders.py
+++ b/cogs/send_introduction_reminders.py
@@ -123,15 +123,15 @@ class SendIntroductionRemindersTaskCog(TeXBotBaseCog):
             )
 
             if member_needs_reminder:
-                if member not in guild.members:
-                        logger.info(
-                            (
-                                "Member with ID: %s does not need to be sent a reminder "
-                                "because they have left the server."
-                            ),
-                            member.id,
-                        )
-                        continue
+                if member not in guild.members:  # HACK: Caching errors can cause the member to no longer be part of the guild, so this check must be performed before sending that member a message # noqa: FIX004
+                    logger.info(
+                        (
+                            "Member with ID: %s does not need to be sent a reminder "
+                            "because they have left the server."
+                        ),
+                        member.id,
+                    )
+                    continue
 
                 async for message in member.history():
                     # noinspection PyUnresolvedReferences

--- a/cogs/send_introduction_reminders.py
+++ b/cogs/send_introduction_reminders.py
@@ -134,7 +134,7 @@ class SendIntroductionRemindersTaskCog(TeXBotBaseCog):
                     if message_contains_opt_in_out_button:
                         await message.edit(view=None)
 
-                if member not in guild.members:  # HACK: Caching errors can cause the member to no longer be part of the guild, so this check must be performed before sending that member a message # noqa: FIX004
+                if member not in guild.members:  # HACK: Caching errors can cause the member to no longer be part of the guild at this point, so this check must be performed before sending that member a message # noqa: FIX004
                     logger.info(
                         (
                             "Member with ID: %s does not need to be sent a reminder "

--- a/cogs/send_introduction_reminders.py
+++ b/cogs/send_introduction_reminders.py
@@ -123,16 +123,6 @@ class SendIntroductionRemindersTaskCog(TeXBotBaseCog):
             )
 
             if member_needs_reminder:
-                if member not in guild.members:  # HACK: Caching errors can cause the member to no longer be part of the guild, so this check must be performed before sending that member a message # noqa: FIX004
-                    logger.info(
-                        (
-                            "Member with ID: %s does not need to be sent a reminder "
-                            "because they have left the server."
-                        ),
-                        member.id,
-                    )
-                    continue
-
                 async for message in member.history():
                     # noinspection PyUnresolvedReferences
                     message_contains_opt_in_out_button: bool = (
@@ -143,6 +133,16 @@ class SendIntroductionRemindersTaskCog(TeXBotBaseCog):
                     )
                     if message_contains_opt_in_out_button:
                         await message.edit(view=None)
+
+                if member not in guild.members:  # HACK: Caching errors can cause the member to no longer be part of the guild, so this check must be performed before sending that member a message # noqa: FIX004
+                    logger.info(
+                        (
+                            "Member with ID: %s does not need to be sent a reminder "
+                            "because they have left the server."
+                        ),
+                        member.id,
+                    )
+                    continue
 
                 await member.send(
                     content=(

--- a/cogs/send_introduction_reminders.py
+++ b/cogs/send_introduction_reminders.py
@@ -124,6 +124,16 @@ class SendIntroductionRemindersTaskCog(TeXBotBaseCog):
             )
 
             if member_needs_reminder:
+                if member not in guild.members:
+                        logger.info(
+                            (
+                                "Member with ID: %s does not need to be sent a reminder "
+                                "because they have left the server."
+                            ),
+                            member.id,
+                        )
+                        continue
+
                 async for message in member.history():
                     # noinspection PyUnresolvedReferences
                     message_contains_opt_in_out_button: bool = (
@@ -134,16 +144,6 @@ class SendIntroductionRemindersTaskCog(TeXBotBaseCog):
                     )
                     if message_contains_opt_in_out_button:
                         await message.edit(view=None)
-
-                    if member not in guild.members:
-                        logger.info(
-                            (
-                                "Member with ID: %s does not need to be sent a reminder "
-                                "because they have left the server."
-                            ),
-                            member.id,
-                        )
-                        continue
 
                 await member.send(
                     content=(


### PR DESCRIPTION
Puts the check to make sure the user is in the guild to be the very first check as this supersedes all others because if they're not in the server there's no point checking anything else. 