### PR TITLE
Add new table names to the make_member cog

### DIFF
--- a/cogs/make_member.py
+++ b/cogs/make_member.py
@@ -176,6 +176,8 @@ class MakeMemberCommandCog(TeXBotBaseCog):
             {
                 "ctl00_Main_rptGroups_ctl05_gvMemberships",
                 "ctl00_Main_rptGroups_ctl03_gvMemberships",
+                "ctl00_ctl00_Main_AdminPageContent_rptGroups_ctl03_gvMemberships",
+                "ctl00_ctl00_Main_AdminPageContent_rptGroups_ctl05_gvMemberships",
             },
         )
         table_id: str


### PR DESCRIPTION
I've kept the old ones in because I already have trust issues, you think I'm gonna trust the Guild to not potentially change them back?