### PR TITLE
Use real defer method for long methods

### DIFF
--- a/cogs/induct.py
+++ b/cogs/induct.py
@@ -196,6 +196,7 @@ class BaseInductCog(TeXBotBaseCog):
         main_guild: discord.Guild = self.bot.main_guild
         guest_role: discord.Role = await self.bot.guest_role
 
+        await ctx.defer(ephemeral=True)
         async with ctx.typing():
 
             logger.debug("Inducting member %s, silent=%s", induction_member, silent)
@@ -280,7 +281,7 @@ class BaseInductCog(TeXBotBaseCog):
                             )
                         break
 
-            await ctx.respond(
+            await ctx.followup.send(
                 content=":white_check_mark: User inducted successfully.",
                 ephemeral=True,
             )

--- a/cogs/make_applicant.py
+++ b/cogs/make_applicant.py
@@ -49,6 +49,7 @@ class BaseMakeApplicantCog(TeXBotBaseCog):
             await self.command_send_error(ctx, message="Cannot make a bot user an applicant!")
             return
 
+        await ctx.defer(ephemeral=True)
         async with ctx.typing():
 
             AUDIT_MESSAGE: Final[str] = (
@@ -91,7 +92,7 @@ class BaseMakeApplicantCog(TeXBotBaseCog):
                             )
                         break
 
-            await ctx.respond(
+            await ctx.followup.send(
                 content=":white_check_mark: User is now an applicant.",
                 ephemeral=True,
             )


### PR DESCRIPTION
The `ctx.typing` co-routine doesn't work the way we thought it did (as a replacement for deferral) so this adds in the proper deferral method as inductions have been timing out. 