### PR TITLE
Remove `prevent-migration-deletion` job from `build-and-publish` job's `needs`

### DIFF
--- a/.github/workflows/check-build-deploy.yaml
+++ b/.github/workflows/check-build-deploy.yaml
@@ -101,22 +101,6 @@ jobs:
             - name: Run pre-commit
               run: uv run -- pre-commit run --all-files --hook-stage manual  # TODO: Add GitHub workflows output format
 
-    prevent-migrations-deletion:
-        runs-on: ubuntu-latest
-
-        permissions:
-            pull-requests: read
-
-        if: github.event_name == 'pull_request'
-
-        steps:
-            - name: Prevent migrations files changing
-              uses: xalvarez/prevent-file-change-action@v2.0.0
-              with:
-                githubToken: ${{ secrets.GITHUB_TOKEN }}
-                pattern: '.*\/db\/.+\/migrations\/\d{4}\w*\.py$'
-                allowNewFiles: true
-
     pymarkdown:
         runs-on: ubuntu-latest
         env:

--- a/.github/workflows/check-build-deploy.yaml
+++ b/.github/workflows/check-build-deploy.yaml
@@ -206,7 +206,7 @@ jobs:
             github.event.pull_request.head.repo.full_name == 'CSSUoB/TeX-Bot-Py-V2'
         runs-on: ubuntu-latest
         environment: publish
-        needs: [mypy, pre-commit, prevent-migrations-deletion, pymarkdown, pytest, ruff-lint, uv-check]
+        needs: [mypy, pre-commit, pymarkdown, pytest, ruff-lint, uv-check]
         permissions:
             contents: read
             packages: write

--- a/.github/workflows/check-build-deploy.yaml
+++ b/.github/workflows/check-build-deploy.yaml
@@ -111,7 +111,7 @@ jobs:
 
         steps:
             - name: Prevent migrations files changing
-              uses: CSSUoB/action-prevent-file-change@v1.7.0
+              uses: xalvarez/prevent-file-change-action@v2.0.0
               with:
                 githubToken: ${{ secrets.GITHUB_TOKEN }}
                 pattern: '.*\/db\/.+\/migrations\/\d{4}\w*\.py$'

--- a/.github/workflows/prevent-migrations-deletion.yaml
+++ b/.github/workflows/prevent-migrations-deletion.yaml
@@ -12,7 +12,7 @@ jobs:
             pull-requests: read
 
         steps:
-            - name: Prevent migrations files changing
+            - name: Prevent migrations files being changed or deleted
               uses: xalvarez/prevent-file-change-action@v2.0.0
               with:
                 githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prevent-migrations-deletion.yaml
+++ b/.github/workflows/prevent-migrations-deletion.yaml
@@ -1,0 +1,20 @@
+name: Prevent deletion of database migration files
+
+on:
+    pull_request_target:
+        branches: [main]
+
+jobs:
+    prevent-migrations-deletion:
+        runs-on: ubuntu-latest
+
+        permissions:
+            pull-requests: read
+
+        steps:
+            - name: Prevent migrations files changing
+              uses: xalvarez/prevent-file-change-action@v2.0.0
+              with:
+                githubToken: ${{ secrets.GITHUB_TOKEN }}
+                pattern: '.*\/db\/.+\/migrations\/\d{4}\w*\.py$'
+                allowNewFiles: true


### PR DESCRIPTION
If it's determined that `prevent-migration-deletion` can run fine on pushes then this check can be added back and the if statement removed from the other job. 

As it stands the build-and-publish job will never run on pushes to main