### PR TITLE
URL construction for member list access using base URL and org ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ PURCHASE_MEMBERSHIP_URL=[Replace with your group\'s purchase=membership URL]
 # One of: DEBUG, INFO, WARNING, ERROR, CRITICAL
 CONSOLE_LOG_LEVEL=INFO
 
+# !!REQUIRED!!
+# The base URL for your organization's membership system
+# Must be a valid URL base (without trailing slash). For example, if your members-list is found on the UoB Guild of Students website, the base URL is https://guildofstudents.com
+MEMBERS_LIST_BASE_URL=[Replace with your organization\'s membership system base URL]
 
 # !!REQUIRED!!
 # The URL to retrieve the list of IDs of people that have purchased a membership to your community group

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Error logs will **always** be sent to the [console](https://wikipedia.org/wiki/T
 
 * `ORGANISATION_ID`: Your Guild society ID. This is used to dynamically create the members list among other needed URLs.
 
+* `MEMBERS_LIST_BASE_URL`: The base URL for your organization's membership system (without trailing slash). For example, if your members-list is found on the UoB Guild of Students website, the base URL is https://guildofstudents.com
+
 * `MEMBERS_LIST_URL_SESSION_COOKIE`: The members-list [URL](https://wikipedia.org/wiki/URL) [session cookie](https://wikipedia.org/wiki/HTTP_cookie#Session_cookie).
 (If your group's members-list is stored at a [URL](https://wikipedia.org/wiki/URL) that requires [authentication](https://wikipedia.org/wiki/Authentication), this [session cookie](https://wikipedia.org/wiki/HTTP_cookie#Session_cookie) should [authenticate](https://wikipedia.org/wiki/Authentication) TeX-Bot to view your group's members-list, as if it were [logged in to the website](https://wikipedia.org/wiki/Login_session) as a Committee member.
 This can be [extracted from your web-browser](https://wikihow.com/View-Cookies), after logging in to view your members-list yourself.

--- a/cogs/make_member.py
+++ b/cogs/make_member.py
@@ -64,11 +64,12 @@ REQUEST_COOKIES: "Final[Mapping[str, str]]" = {
 
 ORGANISATION_ID: "Final[str]" = settings["ORGANISATION_ID"]
 GROUP_NAME: "Final[str]" = settings["_GROUP_FULL_NAME"]
+MEMBERS_LIST_BASE_URL: "Final[str]" = settings["MEMBERS_LIST_BASE_URL"]
 GROUPED_MEMBRS_URL: "Final[str]" = (
-    f"https://guildofstudents.com/organisation/memberlist/{ORGANISATION_ID}/?sort=groups"
+    f"{MEMBERS_LIST_BASE_URL}/organisation/memberlist/{ORGANISATION_ID}/?sort=groups"
 )
 BASE_MEMBERS_URL: "Final[str]" = (
-    f"https://guildofstudents.com/organisation/memberlist/{ORGANISATION_ID}"
+    f"{MEMBERS_LIST_BASE_URL}/organisation/memberlist/{ORGANISATION_ID}"
 )
 
 

--- a/config.py
+++ b/config.py
@@ -710,6 +710,25 @@ class Settings(abc.ABC):
         )
 
     @classmethod
+    def _setup_members_list_base_url(cls) -> None:
+        raw_members_list_base_url: str | None = os.getenv("MEMBERS_LIST_BASE_URL")
+
+        MEMBERS_LIST_BASE_URL_IS_VALID: Final[bool] = bool(
+            raw_members_list_base_url and validators.url(raw_members_list_base_url)
+        )
+        if not MEMBERS_LIST_BASE_URL_IS_VALID:
+            INVALID_MEMBERS_LIST_BASE_URL_MESSAGE: Final[str] = (
+                "MEMBERS_LIST_BASE_URL must be a valid URL base (without trailing slash)."
+            )
+            raise ImproperlyConfiguredError(INVALID_MEMBERS_LIST_BASE_URL_MESSAGE)
+
+        # Remove trailing slash if present
+        if raw_members_list_base_url.endswith("/"):
+            raw_members_list_base_url = raw_members_list_base_url[:-1]
+
+        cls._settings["MEMBERS_LIST_BASE_URL"] = raw_members_list_base_url
+
+    @classmethod
     def _setup_env_variables(cls) -> None:
         """
         Load environment values into the settings dictionary.
@@ -749,6 +768,7 @@ class Settings(abc.ABC):
             cls._setup_moderation_document_url()
             cls._setup_strike_performed_manually_warning_location()
             cls._setup_auto_add_committee_to_threads()
+            cls._setup_members_list_base_url()
         except ImproperlyConfiguredError as improper_config_error:
             webhook_config_logger.error(improper_config_error.message)  # noqa: TRY400
             raise improper_config_error from improper_config_error


### PR DESCRIPTION
This PR modifies how member list URLs are constructed by using a configurable base URL from environment variables instead of hardcoded values. This change improves flexibility and allows the bot to work with different membership systems. Closes #455 
Changes made:
- Added `MEMBERS_LIST_BASE_URL` as a required environment variable
- Added validation for the new environment variable in `config.py`
- Updated URL construction in `cogs/make_member.py` to use the base URL from settings
- Updated documentation in `README.md` and `.env.example` to reflect these changes

### Testing:

- [x] Tested URL construction with different base URLs
- [x] Verified error handling for invalid or missing base URLs
- [x] Confirmed backward compatibility with Guild of Students URL structure