### PR TITLE
Refactor to use Certifi certificates for http requests

### DIFF
--- a/cogs/check_su_platform_authorisation.py
+++ b/cogs/check_su_platform_authorisation.py
@@ -5,6 +5,8 @@ from enum import Enum
 from typing import TYPE_CHECKING, override
 
 import aiohttp
+import certifi
+import ssl
 import bs4
 import discord
 from discord.ext import tasks
@@ -77,11 +79,12 @@ class CheckSUPlatformAuthorisationBaseCog(TeXBotBaseCog):
 
     async def _fetch_url_content_with_session(self, url: str) -> str:
         """Fetch the HTTP content at the given URL, using a shared aiohttp session."""
+        ssl_context: ssl.SSLContext = ssl.create_default_context(cafile=certifi.where())
         async with (
             aiohttp.ClientSession(
                 headers=REQUEST_HEADERS, cookies=REQUEST_COOKIES
             ) as http_session,
-            http_session.get(url) as http_response,
+            http_session.get(url=url, ssl=ssl_context) as http_response,
         ):
             return await http_response.text()
 

--- a/cogs/check_su_platform_authorisation.py
+++ b/cogs/check_su_platform_authorisation.py
@@ -1,13 +1,13 @@
 """Contains cog classes for SU platform access cookie authorisation check interactions."""
 
 import logging
+import ssl
 from enum import Enum
 from typing import TYPE_CHECKING, override
 
 import aiohttp
-import certifi
-import ssl
 import bs4
+import certifi
 import discord
 from discord.ext import tasks
 

--- a/cogs/make_member.py
+++ b/cogs/make_member.py
@@ -5,6 +5,8 @@ import re
 from typing import TYPE_CHECKING
 
 import aiohttp
+import certifi
+import ssl
 import bs4
 import discord
 from bs4 import BeautifulSoup
@@ -156,10 +158,11 @@ class MakeMemberCommandCog(TeXBotBaseCog):
 
             guild_member_ids: set[str] = set()
 
+            ssl_context: ssl.SSLContext = ssl.create_default_context(cafile=certifi.where())
             http_session: aiohttp.ClientSession = aiohttp.ClientSession(
                 headers=REQUEST_HEADERS, cookies=REQUEST_COOKIES
             )
-            async with http_session, http_session.get(GROUPED_MEMBERS_URL) as http_response:
+            async with http_session, http_session.get(url=GROUPED_MEMBERS_URL, ssl=ssl_context) as http_response:
                 response_html: str = await http_response.text()
 
             MEMBER_HTML_TABLE_IDS: Final[frozenset[str]] = frozenset(
@@ -272,10 +275,11 @@ class MemberCountCommandCog(TeXBotBaseCog):
         await ctx.defer(ephemeral=False)
 
         async with ctx.typing():
+            ssl_context: ssl.SSLContext = ssl.create_default_context(cafile=certifi.where())
             http_session: aiohttp.ClientSession = aiohttp.ClientSession(
                 headers=REQUEST_HEADERS, cookies=REQUEST_COOKIES
             )
-            async with http_session, http_session.get(BASE_MEMBERS_URL) as http_response:
+            async with http_session, http_session.get(url=BASE_MEMBERS_URL, ssl=ssl_context) as http_response:
                 response_html: str = await http_response.text()
 
             member_list_div: bs4.Tag | bs4.NavigableString | None = BeautifulSoup(

--- a/cogs/make_member.py
+++ b/cogs/make_member.py
@@ -2,12 +2,12 @@
 
 import logging
 import re
+import ssl
 from typing import TYPE_CHECKING
 
 import aiohttp
-import certifi
-import ssl
 import bs4
+import certifi
 import discord
 from bs4 import BeautifulSoup
 from django.core.exceptions import ValidationError
@@ -159,10 +159,12 @@ class MakeMemberCommandCog(TeXBotBaseCog):
             guild_member_ids: set[str] = set()
 
             ssl_context: ssl.SSLContext = ssl.create_default_context(cafile=certifi.where())
-            http_session: aiohttp.ClientSession = aiohttp.ClientSession(
-                headers=REQUEST_HEADERS, cookies=REQUEST_COOKIES
-            )
-            async with http_session, http_session.get(url=GROUPED_MEMBERS_URL, ssl=ssl_context) as http_response:
+            async with (
+                aiohttp.ClientSession(
+                    headers=REQUEST_HEADERS, cookies=REQUEST_COOKIES
+                ) as http_session,
+                http_session.get(url=GROUPED_MEMBERS_URL, ssl=ssl_context) as http_response,
+            ):
                 response_html: str = await http_response.text()
 
             MEMBER_HTML_TABLE_IDS: Final[frozenset[str]] = frozenset(
@@ -276,10 +278,12 @@ class MemberCountCommandCog(TeXBotBaseCog):
 
         async with ctx.typing():
             ssl_context: ssl.SSLContext = ssl.create_default_context(cafile=certifi.where())
-            http_session: aiohttp.ClientSession = aiohttp.ClientSession(
-                headers=REQUEST_HEADERS, cookies=REQUEST_COOKIES
-            )
-            async with http_session, http_session.get(url=BASE_MEMBERS_URL, ssl=ssl_context) as http_response:
+            async with (
+                aiohttp.ClientSession(
+                    headers=REQUEST_HEADERS, cookies=REQUEST_COOKIES
+                ) as http_session,
+                http_session.get(url=BASE_MEMBERS_URL, ssl=ssl_context) as http_response,
+            ):
                 response_html: str = await http_response.text()
 
             member_list_div: bs4.Tag | bs4.NavigableString | None = BeautifulSoup(


### PR DESCRIPTION
Because the guild website is absolutely fucked and the certificates aren't configured properly, some clients will fail http requests with an SSL verification error. This uses Certifi to remove this bug.