### PR TITLE
Fix ignored `CommandChecks` NameError

### DIFF
--- a/utils/command_checks.py
+++ b/utils/command_checks.py
@@ -68,9 +68,9 @@ class CommandChecks:
     @classmethod
     def is_interaction_user_in_main_guild_failure(cls, check: "CheckFailure") -> bool:
         """Whether the check failed due to the user not being in your Discord guild."""
-        return bool(check.__name__ == cls._check_interaction_user_in_main_guild.__name__)  # type: ignore[attr-defined]
+        return bool(check.__name__ == cls.check_interaction_user_in_main_guild.__name__)  # type: ignore[attr-defined]
 
     @classmethod
     def is_interaction_user_has_committee_role_failure(cls, check: "CheckFailure") -> bool:
         """Whether the check failed due to the user not having the committee role."""
-        return bool(check.__name__ == cls._check_interaction_user_has_committee_role.__name__)  # type: ignore[attr-defined]
+        return bool(check.__name__ == cls.check_interaction_user_has_committee_role.__name__)  # type: ignore[attr-defined]


### PR DESCRIPTION
The `cls._check_interaction_user_in_main_guild` and `cls._check_interaction_user_has_committee_role` have underscores at the start of their attribute names which aren't present when they are declared further up in the class so I removed them to fix the error.