### PR TITLE
Remove committee check on message reporting

### DIFF
--- a/cogs/strike.py
+++ b/cogs/strike.py
@@ -1098,7 +1098,6 @@ class StrikeContextCommandsCog(BaseStrikeCog):
         name="Send Message to Committee",
         description="Sends the selected message to the committee channel for discussion.",
     )
-    @CommandChecks.check_interaction_user_has_committee_role
     @CommandChecks.check_interaction_user_in_main_guild
     async def send_message_to_committee(
         self, ctx: "TeXBotApplicationContext", message: discord.Message


### PR DESCRIPTION
When this is merged the permissions on the Discord GUI will also need changing to allow access to `@Guest`