### PR TITLE
Disable pre-commit Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     "dependencyDashboardLabels": [
         "dependencies"
     ],
-    "enabled": true,
+    "enabled": false,
     "enabledManagers": [
         "github-actions",
         "pep621",


### PR DESCRIPTION
Removing Renovate until https://github.com/renovatebot/renovate/pull/42254 is merged as otherwise it'll keep force pushing itself. Hopefully not long...

When this is fixed to re-enable should just be a simple revert commit for this PR. 