### PR TITLE
Fix command name for archiving categories

### DIFF
--- a/cogs/archive.py
+++ b/cogs/archive.py
@@ -268,7 +268,7 @@ class ArchiveCommandsCog(TeXBotBaseCog):
                 ctx,
                 message=(
                     "Supplied channel to archive is a category - "
-                    "please use the archive-channel command to archive categories."
+                    "please use the archive-category command to archive categories."
                 ),
             )
             return


### PR DESCRIPTION
Fixes a typo in the user feedback of `archive_channel` when user has supplied a category. 