### PR TITLE
Add condition to exclude dependabot from updates

### DIFF
--- a/.github/workflows/pr-auto-updater.yaml
+++ b/.github/workflows/pr-auto-updater.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
     pr-auto-update:
-        if: github.repository == 'CSSUoB/TeX-Bot-Py-V2'
+        if: github.repository == 'CSSUoB/TeX-Bot-Py-V2' && github.actor != 'dependabot[bot]'
         name: Auto-update pull request branches
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
Turns out dependabot doesn't use forks so #820 only fixes for forks, so now we need an extra check for dependabot specifically, slightly annoying but don't think there's a better option. 